### PR TITLE
Use TLS for slack redirection

### DIFF
--- a/databags/home_links.json
+++ b/databags/home_links.json
@@ -12,7 +12,7 @@
         "title": "Upcoming Events"
     },
     "slack": {
-        "href": "http://slack.pspython.com",
+        "href": "https://slack.pspython.com",
         "icon": "fab fa-slack",
         "title": "Slack"
     },


### PR DESCRIPTION
The slack redirect should now support TLS.