### PR TITLE
Added youtube link and 0.8em less of padding

### DIFF
--- a/assets/static/style.css
+++ b/assets/static/style.css
@@ -50,7 +50,7 @@
 }
 
 .home-link-item {
-    padding: 2em;
+    padding: 1.2em;
     color: #FFFFFF;
 }
 

--- a/databags/home_links.json
+++ b/databags/home_links.json
@@ -5,6 +5,7 @@
         "speak",
         "sponsor",
         "donate",
+        "youtube",
         "coc"
     ],
     "upcoming": {
@@ -36,5 +37,10 @@
         "href": "https://psfmember.org/civicrm/contribute/transact/?reset=1&id=15",
         "icon": "fas fa-money-bill-alt",
         "title": "Donate"
+    },
+    "youtube": {
+        "href": "https://www.youtube.com/@pspython/videos",
+        "icon": "fab fa-youtube",
+        "title": "YouTube Channel"
     }
 }


### PR DESCRIPTION
Added the pspython YouTube channel link by adding a new element with link object on the home_links.json file.

Also tweaked the styling slightly on the assets/static/style.css by changing the .home-link-item padding from 2em to 1.2em. This keeps the horizontal line up on the main page from overflowing the viewport area.